### PR TITLE
Added FromSqlRow implementations for std types

### DIFF
--- a/postgres_query/src/extract.rs
+++ b/postgres_query/src/extract.rs
@@ -379,58 +379,123 @@ fn format_columns(columns: &[Column]) -> String {
     total
 }
 
-macro_rules! impl_from_row_for_tuple {
-    (($($elem:ident),+)) => {
-        impl<$($elem),+> FromSqlRow for ($($elem,)+)
-            where $($elem: for<'a> FromSql<'a> + std::fmt::Display),+
-        {
-            const COLUMN_COUNT: usize = impl_from_row_for_tuple!(@count ($($elem),*));
+mod from_row_sql_impls {
+    use super::*;
 
-            fn from_row<R>(row: &R) -> Result<Self, Error>
-            where R: Row {
-                if row.len() != Self::COLUMN_COUNT {
-                    Err(Error::ColumnCount {
-                        expected: Self::COLUMN_COUNT,
-                        found: row.len(),
-                    })
-                } else {
-                    let result = (
-                        $(
-                            row.try_get::<usize, $elem>(
-                                impl_from_row_for_tuple!(@index $elem)
-                            )?,
-                        )+
-                    );
+    use std::rc::Rc;
+    use std::sync::Arc;
 
-                    Ok(result)
+    macro_rules! impl_from_row_for_tuple {
+        (($($elem:ident),+)) => {
+            impl<$($elem),+> FromSqlRow for ($($elem,)+)
+                where $($elem: for<'a> FromSql<'a> + std::fmt::Display),+
+                {
+                    const COLUMN_COUNT: usize = impl_from_row_for_tuple!(@count ($($elem),*));
+
+                    fn from_row<R>(row: &R) -> Result<Self, Error>
+                        where R: Row {
+                            if row.len() != Self::COLUMN_COUNT {
+                                Err(Error::ColumnCount {
+                                    expected: Self::COLUMN_COUNT,
+                                    found: row.len(),
+                                })
+                            } else {
+                                let result = (
+                                    $(
+                                        row.try_get::<usize, $elem>(
+                                            impl_from_row_for_tuple!(@index $elem)
+                                        )?,
+                                    )+
+                                );
+
+                                Ok(result)
+                            }
+                        }
                 }
+        };
+
+        (@index A) => { 0 };
+        (@index B) => { 1 };
+        (@index C) => { 2 };
+        (@index D) => { 3 };
+        (@index E) => { 4 };
+        (@index F) => { 5 };
+        (@index G) => { 6 };
+        (@index H) => { 7 };
+
+        (@count ()) => { 0 };
+        (@count ($head:ident $(, $tail:ident)*)) => {{
+            1 + impl_from_row_for_tuple!(@count ($($tail),*))
+        }};
+    }
+
+    impl_from_row_for_tuple!((A));
+    impl_from_row_for_tuple!((A, B));
+    impl_from_row_for_tuple!((A, B, C));
+    impl_from_row_for_tuple!((A, B, C, D));
+    impl_from_row_for_tuple!((A, B, C, D, E));
+    impl_from_row_for_tuple!((A, B, C, D, E, F));
+    impl_from_row_for_tuple!((A, B, C, D, E, F, G));
+    impl_from_row_for_tuple!((A, B, C, D, E, F, G, H));
+
+    impl<T> FromSqlRow for Option<T>
+    where
+        T: FromSqlRow,
+    {
+        const COLUMN_COUNT: usize = T::COLUMN_COUNT;
+
+        fn from_row<R>(row: &R) -> Result<Self, Error>
+        where
+            R: Row,
+        {
+            match T::from_row(row) {
+                Ok(value) => Ok(Some(value)),
+                Err(_) => Ok(None),
             }
         }
-    };
+    }
 
-    (@index A) => { 0 };
-    (@index B) => { 1 };
-    (@index C) => { 2 };
-    (@index D) => { 3 };
-    (@index E) => { 4 };
-    (@index F) => { 5 };
-    (@index G) => { 6 };
-    (@index H) => { 7 };
+    impl<T, E> FromSqlRow for Result<T, E>
+    where
+        T: FromSqlRow,
+        E: From<Error>,
+    {
+        const COLUMN_COUNT: usize = T::COLUMN_COUNT;
 
-    (@count ()) => { 0 };
-    (@count ($head:ident $(, $tail:ident)*)) => {{
-        1 + impl_from_row_for_tuple!(@count ($($tail),*))
-    }};
+        fn from_row<R>(row: &R) -> Result<Self, Error>
+        where
+            R: Row,
+        {
+            match T::from_row(row) {
+                Ok(value) => Ok(Ok(value)),
+                Err(error) => Ok(Err(E::from(error))),
+            }
+        }
+    }
+
+    macro_rules! impl_from_row_for_wrapper {
+        ($wrapper:ident, $constructor:expr) => {
+            impl<T> FromSqlRow for $wrapper<T>
+            where
+                T: FromSqlRow,
+            {
+                const COLUMN_COUNT: usize = T::COLUMN_COUNT;
+
+                fn from_row<R>(row: &R) -> Result<Self, Error>
+                where
+                    R: Row,
+                {
+                    let value = T::from_row(row)?;
+                    Ok($constructor(value))
+                }
+            }
+        };
+    }
+
+    impl_from_row_for_wrapper!(Box, Box::new);
+    impl_from_row_for_wrapper!(Rc, Rc::new);
+    impl_from_row_for_wrapper!(Arc, Arc::new);
 }
-
-impl_from_row_for_tuple!((A));
-impl_from_row_for_tuple!((A, B));
-impl_from_row_for_tuple!((A, B, C));
-impl_from_row_for_tuple!((A, B, C, D));
-impl_from_row_for_tuple!((A, B, C, D, E));
-impl_from_row_for_tuple!((A, B, C, D, E, F));
-impl_from_row_for_tuple!((A, B, C, D, E, F, G));
-impl_from_row_for_tuple!((A, B, C, D, E, F, G, H));
 
 #[cfg(test)]
 mod tests {

--- a/postgres_query/tests/execute.rs
+++ b/postgres_query/tests/execute.rs
@@ -736,3 +736,45 @@ async fn parameter_list() -> Result {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn optional_flatten() -> Result {
+    let mut client = establish().await?;
+    let tx = client.transaction().await?;
+
+    #[derive(FromSqlRow, Clone)]
+    #[row(split)]
+    struct Family {
+        #[row(flatten, split = "id")]
+        child: Person,
+        #[row(flatten, split = "id")]
+        father: Option<Person>,
+    }
+
+    #[derive(FromSqlRow, Clone)]
+    struct Person {
+        id: i32,
+        name: String,
+    }
+
+    let families: Vec<Family> = query!(
+        "SELECT 1 as id, 'Luke Skywalker' as name, 2 as id, 'Darth Vader' as name
+        UNION ALL SELECT 2, 'Darth Vader', NULL, NULL"
+    )
+    .fetch(&tx)
+    .await?;
+
+    let luke = families[0].clone();
+    let vader = families[1].clone();
+
+    assert_eq!(luke.child.id, 1);
+    assert_eq!(luke.child.name, "Luke Skywalker");
+    assert_eq!(luke.father.as_ref().unwrap().id, 2);
+    assert_eq!(luke.father.as_ref().unwrap().name, "Darth Vader");
+
+    assert_eq!(vader.child.id, 2);
+    assert_eq!(vader.child.name, "Darth Vader");
+    assert!(vader.father.is_none());
+
+    Ok(())
+}

--- a/postgres_query/tests/execute.rs
+++ b/postgres_query/tests/execute.rs
@@ -806,8 +806,53 @@ async fn optional_flatten_invalid_type() -> Result {
     .fetch::<Family, _>(&tx)
     .await;
 
-    // 'a number' is not of the correct type, so this should fail 
+    // 'a number' is not of the correct type, so this should fail
     assert!(families.is_err());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn optional_flatten_nested_option() -> Result {
+    let mut client = establish().await?;
+    let tx = client.transaction().await?;
+
+    #[derive(FromSqlRow, Clone)]
+    #[row(split)]
+    struct Family {
+        #[row(flatten, split = "id")]
+        child: Person,
+        #[row(flatten, split = "id")]
+        father: Option<Person>,
+    }
+
+    #[derive(FromSqlRow, Clone)]
+    struct Person {
+        id: i32,
+        name: Option<String>,
+    }
+
+    let families: Vec<Family> = query!(
+        "SELECT 1 as id, 'Luke Skywalker' as name, 2 as id, 'Darth Vader' as name
+        UNION ALL SELECT 2, 'Darth Vader', 3, NULL"
+    )
+    .fetch(&tx)
+    .await?;
+
+    let luke = families[0].clone();
+    let vader = families[1].clone();
+
+    assert_eq!(luke.child.id, 1);
+    assert_eq!(luke.child.name.unwrap(), "Luke Skywalker");
+    let luke_father = luke.father.unwrap();
+    assert_eq!(luke_father.id, 2);
+    assert_eq!(luke_father.name, Some("Darth Vader".into()));
+
+    assert_eq!(vader.child.id, 2);
+    assert_eq!(vader.child.name.unwrap(), "Darth Vader");
+    let vader_father = vader.father.unwrap();
+    assert_eq!(vader_father.id, 3);
+    assert_eq!(vader_father.name, None);
 
     Ok(())
 }


### PR DESCRIPTION
Resolves #8.

Wrapping something in `Option<T>` or `Result<T, E>` completely silences any errors coming from within. We would probably want to add some flag to the `Error` type to determine if there was a serious error (such as missing a column or having a type mismatch).