### PR TITLE
Upgrade to tokio 0.3 and tokio-postgres 0.6

### DIFF
--- a/postgres_query/Cargo.toml
+++ b/postgres_query/Cargo.toml
@@ -17,16 +17,16 @@ path = "examples/basic.rs"
 
 [dependencies]
 postgres_query_macro = { version = "0.3.1", path = "../postgres_query_macro" }
-proc-macro-hack = "0.5.11"
-postgres-types = "0.1.0"
-serde = "1.0.104"
-tokio-postgres = "0.5.1"
-futures = "0.3.1"
-async-trait = "0.1.22"
-thiserror = "1.0.9"
+proc-macro-hack = "0.5.19"
+postgres-types = "0.1.3"
+serde = "1.0.117"
+tokio-postgres = "0.6.0"
+futures = "0.3.7"
+async-trait = "0.1.41"
+thiserror = "1.0.22"
 
 [dev-dependencies]
-bytes = "0.5.3"
-tokio = { version = "0.2.6", features = ["macros"] }
-structopt = "0.3.7"
-anyhow = "1.0.26"
+bytes = "0.5.6"
+tokio = { version = "0.3.3", features = ["macros", "rt-multi-thread"] }
+structopt = "0.3.20"
+anyhow = "1.0.34"

--- a/postgres_query_macro/Cargo.toml
+++ b/postgres_query_macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "postgres_query_macro"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Christofer Nolander <christofer.nolander@gmail.com>"]
 edition = "2018"
 description = "Write and execute SQL queries with ease"

--- a/postgres_query_macro/Cargo.toml
+++ b/postgres_query_macro/Cargo.toml
@@ -12,7 +12,7 @@ readme = "../README.md"
 proc-macro = true
 
 [dependencies]
-proc-macro-hack = "0.5.11"
-quote = "1.0.2"
-syn = { version = "1.0.11", features = ["full"] }
-proc-macro2 = "1.0.6"
+proc-macro-hack = "0.5.19"
+quote = "1.0.7"
+syn = { version = "1.0.48", features = ["full"] }
+proc-macro2 = "1.0.24"


### PR DESCRIPTION
Excellent work on the project, this PR bumps the tokio-postgres version to 0.6, tokio to 0.3, and everything else to the most recent minor version, all test pass and no changes are required to the code.