### PR TITLE
Added prepared_static for &GenericClient

### DIFF
--- a/postgres_query/src/client.rs
+++ b/postgres_query/src/client.rs
@@ -145,6 +145,10 @@ macro_rules! client_deref_impl {
                 T::prepare(self, sql).await
             }
 
+            async fn prepare_static(&self, sql: &'static str) -> Result<Statement, SqlError> {
+                T::prepare_static(self, sql).await
+            }
+
             async fn execute_raw<'a>(
                 &'a self,
                 statement: &Statement,

--- a/postgres_query/src/client.rs
+++ b/postgres_query/src/client.rs
@@ -69,6 +69,11 @@ impl GenericClient for Client {
     }
 
     #[deny(unconditional_recursion)]
+    async fn prepare_static(&self, sql: &'static str) -> Result<Statement, SqlError> {
+        Client::prepare_static(self, sql).await
+    }
+
+    #[deny(unconditional_recursion)]
     async fn execute_raw<'a>(
         &'a self,
         statement: &Statement,
@@ -96,6 +101,11 @@ impl GenericClient for DpClient {
     }
 
     #[deny(unconditional_recursion)]
+    async fn prepare_static(&self, sql: &'static str) -> Result<Statement, SqlError> {
+        DpClientWrapper::prepare_static(self, sql).await
+    }
+
+    #[deny(unconditional_recursion)]
     async fn execute_raw<'a>(
         &'a self,
         statement: &Statement,
@@ -118,6 +128,10 @@ impl GenericClient for DpClient {
 impl GenericClient for Transaction<'_> {
     async fn prepare(&self, sql: &str) -> Result<Statement, SqlError> {
         Transaction::prepare(self, sql).await
+    }
+
+    async fn prepare_static(&self, sql: &'static str) -> Result<Statement, SqlError> {
+        Transaction::prepare_static(self, sql).await
     }
 
     async fn execute_raw<'a>(

--- a/postgres_query/src/client.rs
+++ b/postgres_query/src/client.rs
@@ -69,11 +69,6 @@ impl GenericClient for Client {
     }
 
     #[deny(unconditional_recursion)]
-    async fn prepare_static(&self, sql: &'static str) -> Result<Statement, SqlError> {
-        Client::prepare_static(self, sql).await
-    }
-
-    #[deny(unconditional_recursion)]
     async fn execute_raw<'a>(
         &'a self,
         statement: &Statement,
@@ -101,11 +96,6 @@ impl GenericClient for DpClient {
     }
 
     #[deny(unconditional_recursion)]
-    async fn prepare_static(&self, sql: &'static str) -> Result<Statement, SqlError> {
-        DpClientWrapper::prepare_static(self, sql).await
-    }
-
-    #[deny(unconditional_recursion)]
     async fn execute_raw<'a>(
         &'a self,
         statement: &Statement,
@@ -128,10 +118,6 @@ impl GenericClient for DpClient {
 impl GenericClient for Transaction<'_> {
     async fn prepare(&self, sql: &str) -> Result<Statement, SqlError> {
         Transaction::prepare(self, sql).await
-    }
-
-    async fn prepare_static(&self, sql: &'static str) -> Result<Statement, SqlError> {
-        Transaction::prepare_static(self, sql).await
     }
 
     async fn execute_raw<'a>(

--- a/postgres_query/src/client/cache.rs
+++ b/postgres_query/src/client/cache.rs
@@ -65,6 +65,14 @@ where
         }
     }
 
+    /// Wrap new client with an existing cache.
+    pub fn map_clone<U: GenericClient>(&self, client: U) -> Caching<U> {
+        Caching {
+            client,
+            cache: self.cache.clone(),
+        }
+    }
+
     /// Return the inner client.
     pub fn into_inner(self) -> C {
         self.client
@@ -213,10 +221,11 @@ macro_rules! impl_cached_transaction {
         impl Caching<$client> {
             /// Start a new transaction that shares the same cache as the current client.
             pub async fn transaction(&mut self) -> Result<Caching<$transaction>, Error> {
-                <$client>::transaction(self)
+                let cache = self.cache.clone();
+                let tx = <$client>::transaction(self)
                     .await
-                    .map(Caching::new)
-                    .map_err(Error::BeginTransaction)
+                    .map_err(Error::BeginTransaction)?;
+                Ok(Caching { client: tx, cache })
             }
         }
     };


### PR DESCRIPTION
Missed method makes impossible to use Caching client. Queries are prepared but never cached.